### PR TITLE
feat: Don't display loading indicator when querystate is 'reload'

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -227,12 +227,7 @@ const UnMemoizedChannel = <
 >(
   props: PropsWithChildren<ChannelProps<StreamChatGenerics, V>>,
 ) => {
-  const {
-    channel: propsChannel,
-    EmptyPlaceholder = null,
-    LoadingErrorIndicator,
-    LoadingIndicator = DefaultLoadingIndicator,
-  } = props;
+  const { channel: propsChannel, EmptyPlaceholder = null, LoadingErrorIndicator } = props;
 
   const {
     channel: contextChannel,
@@ -247,14 +242,6 @@ const UnMemoizedChannel = <
   const channel = propsChannel || contextChannel;
 
   const className = clsx(chatClass, theme, channelClass);
-
-  if (channelsQueryState.queryInProgress === 'reload' && LoadingIndicator) {
-    return (
-      <div className={className}>
-        <LoadingIndicator />
-      </div>
-    );
-  }
 
   if (channelsQueryState.error && LoadingErrorIndicator) {
     return (


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

We are making this change because otherwise the message list is replaced with a loading indicator when the channel list is queried, which is behaviour we don't want with our side-by-side display of both channel list and message list.

### 🛠 Implementation details

I've simply removed the code that will show the loading indcator when the `queryInProgress` is `reload`. This is functionally the same as my janky fix, but the correct loading indicator will still be used when loading more messages, fixing the error when paginating.

I haven't been able to verify that this functions as I intend because I haven't been able to reference the fork locally in op-console.

### 🎨 UI Changes

🙅 
